### PR TITLE
fix(observability): resync grafana admin password on every start

### DIFF
--- a/kubernetes/apps/observability/grafana/instance/grafana.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafana.yaml
@@ -76,6 +76,57 @@ spec:
               envFrom:
                 - secretRef:
                     name: grafana-admin-secret
+            # Resync DB admin password with GF_SECURITY_ADMIN_PASSWORD on every start.
+            # Grafana only applies admin_password at first user creation, so any rotation
+            # of the secret in 1Password would otherwise leave grafana-operator unable
+            # to authenticate (403 folders:create -> dashboards stop syncing).
+            - name: reset-admin-password
+              image: docker.io/grafana/grafana:12.1.0
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -ec
+                - grafana cli --homepath=/usr/share/grafana admin reset-admin-password "${GF_SECURITY_ADMIN_PASSWORD}"
+              env:
+                - name: GF_SECURITY_ADMIN_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: grafana-admin-secret
+                      key: admin-password
+                - name: GF_DATABASE_TYPE
+                  valueFrom:
+                    secretKeyRef:
+                      name: grafana-admin-secret
+                      key: GF_DATABASE_TYPE
+                - name: GF_DATABASE_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: grafana-admin-secret
+                      key: GF_DATABASE_HOST
+                - name: GF_DATABASE_NAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: grafana-admin-secret
+                      key: GF_DATABASE_NAME
+                - name: GF_DATABASE_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: grafana-admin-secret
+                      key: GF_DATABASE_USER
+                - name: GF_DATABASE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: grafana-admin-secret
+                      key: GF_DATABASE_PASSWORD
+                - name: GF_DATABASE_SSL_MODE
+                  valueFrom:
+                    secretKeyRef:
+                      name: grafana-admin-secret
+                      key: GF_DATABASE_SSL_MODE
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
           containers:
             - name: grafana
               env:


### PR DESCRIPTION
## Summary
- Adds an `reset-admin-password` initContainer to the Grafana CR that runs `grafana cli admin reset-admin-password` against the Grafana DB using the current value of `GF_SECURITY_ADMIN_PASSWORD` from `grafana-admin-secret`.
- Makes grafana-operator able to authenticate against Grafana again after any rotation of the 1Password item.

## Root cause
- `grafana-admin-secret.admin-password` (synced from 1Password via ExternalSecret) was rotated at some point.
- Both the deployment env var and `grafana-admin-credentials` (auto-managed by grafana-operator) reflect the new value.
- Grafana only applies `admin_password` at the first user creation; subsequent restarts ignore the env var, so the DB still stores the old password.
- grafana-operator basic-auth → 401 → falls back to anonymous (Viewer role) → 403 createFolderForbidden → dashboard reconcile loop fails (5 200+ errors observed on `grafana-operator` and 7 800+ on `grafana-deployment` within 30 min).

## Test plan
- [ ] After merge + flux reconcile, watch the new pod roll
- [ ] `kubectl -n observability logs <new-grafana-pod> -c reset-admin-password` → expect `Admin password changed successfully` (or similar)
- [ ] `kubectl -n observability logs deploy/grafana-operator --tail=50` → no more 403 / 401
- [ ] `kubectl get grafanadashboard -A` → reconciliation status clean