### PR TITLE
feat(gitea): migrate to shared redis, retire embedded valkey-cluster

### DIFF
--- a/kubernetes/apps/databases/redis/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/redis/app/helmrelease.yaml
@@ -36,24 +36,33 @@ spec:
     auth:
       enabled: false
       sentinel: false
+    commonConfiguration: |-
+      maxmemory 384mb
+      maxmemory-policy allkeys-lru
+      save 300 100
+      save 60 10000
     master:
       persistence:
-        enabled: false
+        enabled: true
+        storageClass: ceph-block
+        size: 2Gi
       resources:
         requests:
-          cpu: 15m
-          memory: 20Mi
+          cpu: 50m
+          memory: 128Mi
         limits:
-          memory: 100Mi
+          memory: 512Mi
     replica:
       persistence:
-        enabled: false
+        enabled: true
+        storageClass: ceph-block
+        size: 2Gi
       resources:
         requests:
-          cpu: 15m
-          memory: 20Mi
+          cpu: 50m
+          memory: 128Mi
         limits:
-          memory: 100Mi
+          memory: 512Mi
     sentinel:
       enabled: false
       masterSet: redis-master

--- a/kubernetes/apps/dev/gitea/app/helmrelease.yaml
+++ b/kubernetes/apps/dev/gitea/app/helmrelease.yaml
@@ -46,6 +46,8 @@ spec:
       enabled: false
     redis:
       enabled: false
+    valkey-cluster:
+      enabled: false
     postgresql-ha:
       enabled: false
     persistence:
@@ -81,10 +83,13 @@ spec:
           ALLOWED_HOST_LIST: "*"
         cache:
           ADAPTER: redis
-          HOST: redis://redis-master.databases.svc.cluster.local:6379
+          HOST: redis://redis-master.databases.svc.cluster.local:6379/5
         session:
           PROVIDER: redis
-          PROVIDER_CONFIG: redis://redis-master.databases.svc.cluster.local:6379
+          PROVIDER_CONFIG: redis://redis-master.databases.svc.cluster.local:6379/5
+        queue:
+          TYPE: redis
+          CONN_STR: redis://redis-master.databases.svc.cluster.local:6379/5
         service:
           DISABLE_REGISTRATION: false
           ALLOW_ONLY_EXTERNAL_REGISTRATION: true
@@ -133,15 +138,6 @@ spec:
         enabled: true
         serviceMonitor:
           enabled: true
-    valkey-cluster:
-      valkey:
-        resources:
-          requests:
-            cpu: 100m
-            memory: 128Mi
-          limits:
-            cpu: 500m
-            memory: 256Mi
   valuesFrom:
     - targetPath: gitea.admin.password
       kind: Secret


### PR DESCRIPTION
## Summary
- Disable the gitea chart's embedded `valkey-cluster` sub-chart (broken after Talos v1.13.2 powercycles corrupted its AOF; bitnami init script deadlocks on fresh PVCs).
- Point gitea's `cache`, `session`, and `queue` at the shared `databases/redis` master, scoped to DB 5 to start a per-app DB convention (others remain on DB 0 for now).
- Bump shared redis: enable RDB persistence (2Gi ceph-block on master + replica), raise memory limit 100Mi → 512Mi with `maxmemory 384mb` + `allkeys-lru` eviction, scale CPU request 15m → 50m.
- Add save policy `300 100` + `60 10000` so cache survives pod restarts.

## Context
After the Talos v1.13.0 → v1.13.2 upgrade powercycled all 3 nodes, the gitea-valkey-cluster ended up with 2/3 masters in CrashLoopBackOff (AOF replay failure), `cluster_state:fail`. Recovery via PVC wipe failed because the gitea chart's bash wrapper bootstraps non-creator pods only when nodes.conf already exists — chicken-and-egg on fresh PVCs. Sharing the existing `databases/redis` (master/replica, NOT cluster mode) is simpler and gives us DB-level isolation per app.

## Test plan
- [ ] Flux reconciles `databases/redis` HelmRelease without remediation retries
- [ ] `redis-master-0` and `redis-replicas-0` pods come up Ready with PVCs Bound on ceph-block
- [ ] Existing redis-clients (authelia, harbor, twenty, billionmail, rybbit, shlink) reconnect (brief ~30s blip expected)
- [ ] Flux reconciles `dev/gitea` HelmRelease; helm removes the `gitea-valkey-cluster` StatefulSet
- [ ] Gitea pod restarts; `grep -A1 "^\\[cache\\|^\\[session\\|^\\[queue" /data/gitea/conf/app.ini` inside the pod shows `redis-master.databases.svc.cluster.local:6379/5`
- [ ] gitea.g-eye.io loads without 3s+ session timeouts
- [ ] `valkey-cli -h redis-master.databases.svc.cluster.local SELECT 5 ; DBSIZE` shows growing keys after browsing gitea

## Cleanup (manual, post-merge)
```bash
kubectl -n dev delete pvc valkey-data-gitea-valkey-cluster-0 valkey-data-gitea-valkey-cluster-1 valkey-data-gitea-valkey-cluster-2
```