### PR TITLE
feat(databases): enable redis persistence with RDB snapshots

### DIFF
--- a/kubernetes/apps/databases/redis/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/redis/app/helmrelease.yaml
@@ -39,9 +39,13 @@ spec:
     commonConfiguration: |-
       maxmemory 384mb
       maxmemory-policy allkeys-lru
+      save 300 100
+      save 60 10000
     master:
       persistence:
-        enabled: false
+        enabled: true
+        storageClass: ceph-block
+        size: 2Gi
       resources:
         requests:
           cpu: 50m
@@ -50,7 +54,9 @@ spec:
           memory: 512Mi
     replica:
       persistence:
-        enabled: false
+        enabled: true
+        storageClass: ceph-block
+        size: 2Gi
       resources:
         requests:
           cpu: 50m


### PR DESCRIPTION
## Summary

Enable on-disk persistence for the shared redis HelmRelease so cache and session data survive pod restarts. RDB-only (no AOF), 2Gi ceph-block PVCs on master + replicas. Follows up #2590 which deferred persistence because of the STS-immutable constraint.

### Changes
- `persistence.enabled: false → true` on master and replica
- `storageClass: ceph-block`, `size: 2Gi`
- Add `save 300 100` and `save 60 10000` to commonConfiguration

## ⚠️ Pre-merge runbook

`volumeClaimTemplates` is immutable on existing StatefulSets, so the helm upgrade will fail unless we recreate the StatefulSets manually first. The `--cascade=orphan` strategy keeps the pods serving traffic, so redis stays available during the operation.

```bash
# 1. Drop the StatefulSets but keep the pods running (no downtime)
kubectl -n databases delete sts redis-master redis-replicas --cascade=orphan

# 2. Merge this PR (helm-controller will create new STSes with volumeClaimTemplates)

# 3. Reconcile to trigger immediately (otherwise wait up to 1h)
flux reconcile helmrelease redis -n databases

# 4. Watch the rolling adoption (one pod replaced at a time, ~30s blip per pod)
kubectl -n databases get pods -l app.kubernetes.io/instance=redis -w
```

## Test plan
- [ ] Helm release advances past v42 without remediation retries
- [ ] `redis-master-0` recreated with PVC `redis-data-redis-master-0` Bound on ceph-block
- [ ] `redis-replicas-{0,1,2}` recreated with `redis-data-redis-replicas-N` Bound
- [ ] `redis-cli config get save` returns `300 100 60 10000`
- [ ] `redis-cli config get maxmemory` returns `402653184` (unchanged from #2590)
- [ ] Existing clients (authelia, harbor, gitea, twenty, billionmail, rybbit, shlink) reconnect within seconds — check pod logs for any cascading errors
- [ ] After save trigger or `redis-cli BGSAVE`, `dump.rdb` exists in `/data` inside master pod
- [ ] Manual master restart → keys still present after reconnect