### PR TITLE
feat(observability): pin Kubernetes dashboards to Kubernetes folder

### DIFF
--- a/kubernetes/apps/observability/grafana/instance/grafanadashboards.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafanadashboards.yaml
@@ -126,6 +126,7 @@ metadata:
   name: kubernetes-api-server
 spec:
   allowCrossNamespaceImport: true
+  folderRef: kubernetes
   instanceSelector:
     matchLabels:
       grafana.internal/instance: grafana
@@ -141,6 +142,7 @@ metadata:
   name: kubernetes-coredns
 spec:
   allowCrossNamespaceImport: true
+  folderRef: kubernetes
   instanceSelector:
     matchLabels:
       grafana.internal/instance: grafana
@@ -156,6 +158,7 @@ metadata:
   name: kubernetes-global
 spec:
   allowCrossNamespaceImport: true
+  folderRef: kubernetes
   instanceSelector:
     matchLabels:
       grafana.internal/instance: grafana
@@ -171,6 +174,7 @@ metadata:
   name: kubernetes-namespaces
 spec:
   allowCrossNamespaceImport: true
+  folderRef: kubernetes
   instanceSelector:
     matchLabels:
       grafana.internal/instance: grafana
@@ -186,6 +190,7 @@ metadata:
   name: kubernetes-nodes
 spec:
   allowCrossNamespaceImport: true
+  folderRef: kubernetes
   instanceSelector:
     matchLabels:
       grafana.internal/instance: grafana
@@ -201,6 +206,7 @@ metadata:
   name: kubernetes-pods
 spec:
   allowCrossNamespaceImport: true
+  folderRef: kubernetes
   instanceSelector:
     matchLabels:
       grafana.internal/instance: grafana
@@ -216,6 +222,7 @@ metadata:
   name: kubernetes-volumes
 spec:
   allowCrossNamespaceImport: true
+  folderRef: kubernetes
   instanceSelector:
     matchLabels:
       grafana.internal/instance: grafana

--- a/kubernetes/apps/observability/grafana/instance/grafanafolders.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafanafolders.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanafolder_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: kubernetes
+  namespace: observability
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  title: Kubernetes
+  # Claim the pre-existing folder created via the UI so the operator
+  # adopts it instead of creating a duplicate "Kubernetes" folder.
+  uid: df1j7uqslvbb4c

--- a/kubernetes/apps/observability/grafana/instance/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana/instance/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./grafana.yaml
   - ./grafanadatasource.yaml
+  - ./grafanafolders.yaml
   - ./grafanadashboards.yaml
   - ./httproute.yaml
   - ./servicemonitor.yaml


### PR DESCRIPTION
## Summary
- Adds a `GrafanaFolder` CR for `Kubernetes` claiming the existing folder UID `df1j7uqslvbb4c` (created via the UI previously).
- Wires `folderRef: kubernetes` into the 7 `kubernetes-*` `GrafanaDashboard` CRs so they no longer fall back to the namespace-default folder (`observability`).

## Why
Operator-managed dashboards default to a folder named like the CR namespace. So the K8s-themed dashboards (`kubernetes-api-server`, `kubernetes-coredns`, `kubernetes-global`, `kubernetes-namespaces`, `kubernetes-nodes`, `kubernetes-pods`, `kubernetes-volumes`) ended up in `observability` instead of `Kubernetes`.

## Scope note
This PR only covers the 7 operator-managed K8s CRs. The remaining ~48 dashboards in root are sourced from configmaps (`grafana_dashboard=1`) that were provisioned by a sidecar no longer running in this Grafana pod. Reorganizing those was done out-of-band via a targeted SQL update against `dashboard.folder_uid` — a follow-up PR could either run a fresh `k8s-sidecar` container that respects `grafana_folder` annotations, or migrate the configmaps to `GrafanaDashboard` CRs.

## Test plan
- [ ] Flux applies, then `kubectl get grafanafolder -n observability` shows `kubernetes` Ready
- [ ] All 7 `kubernetes-*` GrafanaDashboards `ApplySuccessful`
- [ ] In Grafana UI, the 7 dashboards appear under the `Kubernetes` folder