### PR TITLE
fix(databases): bump redis helmrelease timeout to 15m

### DIFF
--- a/kubernetes/apps/databases/redis/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/redis/app/helmrelease.yaml
@@ -20,6 +20,7 @@ metadata:
   name: redis
 spec:
   interval: 1h
+  timeout: 15m
   chartRef:
     kind: OCIRepository
     name: redis


### PR DESCRIPTION
## Summary
The 5-minute default `spec.timeout` on the redis HelmRelease isn't enough for the ceph-block PVC rollout of 4 redis pods (master + 3 replicas) sequentially. After #2591 enabled persistence, the upgrade reached ready state in ~6 minutes — just past the timeout — leaving the HelmRelease stalled in `RollbackSucceeded` state even though the cluster converged correctly (`dump.rdb` is being written every 60s).

## Test plan
- [ ] After merge + manual suspend/resume to clear the retry counter, HelmRelease moves to `Ready: True`
- [ ] Subsequent reconciles complete cleanly without timeout