### PR TITLE
fix(databases): disable helm wait on redis upgrades

### DIFF
--- a/kubernetes/apps/databases/redis/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/redis/app/helmrelease.yaml
@@ -29,6 +29,7 @@ spec:
       retries: 3
   upgrade:
     cleanupOnFail: true
+    disableWait: true
     remediation:
       retries: 3
   uninstall:


### PR DESCRIPTION
## Summary
The 15m timeout from #2594 isn't enough to recover from the state-divergence loop after the persistence migration: each helm upgrade attempt re-patches the configmap, which makes reloader restart pods, which triggers a fresh STS rollout, which exceeds helm's wait window. The release stays in `Stalled: RetriesExceeded` indefinitely even though the cluster is fully converged (pods all 2/2 Running, PVCs Bound, `dump.rdb` being written every 60s).

With `disableWait: true`, helm completes the upgrade as soon as the patch lands; kstatus/Flux still tracks eventual readiness via the post-upgrade reconcile, so we don't lose health visibility — we just stop blocking the release on rollout state.

## Test plan
- [ ] After merge + a `flux reconcile hr redis -n databases --reset`, HelmRelease moves to `Ready: True`
- [ ] `kubectl -n databases get pods -l app.kubernetes.io/instance=redis` shows 4 pods 2/2 Running
- [ ] `redis-cli config get save` still returns `300 100 60 10000`