### PR TITLE
feat(observability): add VictoriaLogs datasource to Grafana

### DIFF
--- a/kubernetes/apps/observability/grafana/instance/grafana.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafana.yaml
@@ -174,7 +174,7 @@ spec:
                       name: grafana-admin-secret
                       key: TESLAMATE_DB_PASSWORD
                 - name: GF_INSTALL_PLUGINS
-                  value: "grafana-clock-panel,grafana-piechart-panel,grafana-worldmap-panel,natel-discrete-panel,pr0ps-trackmap-panel,vonage-status-panel"
+                  value: "grafana-clock-panel,grafana-piechart-panel,grafana-worldmap-panel,natel-discrete-panel,pr0ps-trackmap-panel,vonage-status-panel,victoriametrics-logs-datasource"
                 - name: GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS
                   value: "natel-discrete-panel,pr0ps-trackmap-panel,panodata-map-panel"
               securityContext:

--- a/kubernetes/apps/observability/grafana/instance/grafanadatasource.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafanadatasource.yaml
@@ -20,6 +20,24 @@ spec:
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDatasource
 metadata:
+  name: victoria-logs
+spec:
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasource:
+    type: victoriametrics-logs-datasource
+    name: VictoriaLogs
+    uid: victorialogs
+    access: proxy
+    url: http://victoria-logs-server.observability.svc.cluster.local:9428
+    jsonData:
+      maxLines: 1000
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadatasource_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
   name: alertmanager
 spec:
   instanceSelector:


### PR DESCRIPTION
## Summary
- Install the `victoriametrics-logs-datasource` plugin in the Grafana instance
- Register a `GrafanaDatasource` (uid `victorialogs`) pointed at `victoria-logs-server.observability.svc:9428`
- Brings logs into Grafana Explore next to Prometheus metrics

## Why
Today logs only live in VMUI at https://victoria-logs.g-eye.io. Putting VictoriaLogs in Grafana lets dashboards and Explore use the same time range, variables, and split-pane workflow as metrics, which is the foundation for the rest of the VictoriaLogs improvements (vlalert, log dashboards, derived field links).

## Test plan
- [ ] Flux reconciles `grafana` Kustomization
- [ ] Grafana pod restarts and the plugin shows up in `Connections → Data sources`
- [ ] Open Explore → VictoriaLogs → run `_stream:{k_namespace_name="observability"}` and confirm log lines render