### PR TITLE
feat(observability): extend VictoriaLogs retention to 30d, PVC to 60Gi

### DIFF
--- a/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
@@ -13,11 +13,11 @@ spec:
     fullnameOverride: victoria-logs
     server:
       extraArgs:
-        retentionPeriod: 7d
+        retentionPeriod: 30d
       persistentVolume:
         enabled: true
         storageClassName: ceph-block
-        size: 20Gi
+        size: 60Gi
       route:
         enabled: true
         hostnames:


### PR DESCRIPTION
## Summary
- `retentionPeriod`: 7d → 30d
- VL PVC: 20Gi → 60Gi (ceph-block)

## Why
7d is too short for the cluster's weekly investigation cadence — by the time you notice a flake you can't see when it started. 30d at current volume comfortably fits in 60Gi with room for retries/compaction.

## Risk
- PVC resize is online for ceph-block but the VL StatefulSet may roll once. Logs are not persisted during the brief restart.
- If volume grows faster than expected, monitor `vm_data_size_bytes` and bump again. Single-node VL stays well within capacity for this homelab.

## Test plan
- [ ] Flux reconciles VL HelmRelease
- [ ] `kubectl -n observability get pvc` shows the new 60Gi size
- [ ] `kubectl -n observability exec sts/victoria-logs-server -- /victoria-logs-prod -version` (or process args) shows `-retentionPeriod=30d`