### PR TITLE
feat(observability): enrich fluent-bit stream fields with container and node

### DIFF
--- a/kubernetes/apps/observability/fluent-bit/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/fluent-bit/app/helmrelease.yaml
@@ -84,7 +84,7 @@ spec:
           match kubernetes.*
           host victoria-logs-server.observability.svc.cluster.local
           port 9428
-          uri /insert/jsonline?_stream_fields=stream,k_namespace_name,k_pod_name,app,cluster&_msg_field=log&_time_field=date
+          uri /insert/jsonline?_stream_fields=stream,k_namespace_name,k_pod_name,k_container_name,k_host,app,cluster&_msg_field=log&_time_field=date
           format json_lines
           json_date_format iso8601
           compress gzip


### PR DESCRIPTION
## Summary
- Add `k_container_name` and `k_host` to the VictoriaLogs `_stream_fields` set in fluent-bit's HTTP output

## Why
The current stream-field set (`stream, k_namespace_name, k_pod_name, app, cluster`) hides two dimensions that matter for investigation:
- **Container**: multi-container pods (sidecars, init containers, agent + app) all collapse to one pod stream
- **Node**: \"what was happening on talos-01 at 14:30?\" requires a slow message-content scan instead of a fast stream filter

Both fields are bounded cardinality (containers per pod ~1-3, nodes are a fixed set) so this won't explode VL's stream count.

## Caveat
VictoriaLogs keys streams by the set of stream fields at write time. Logs ingested before this change keep the old keying; logs after this commit will use the richer keying. Both remain queryable, but only new logs will be filterable by `k_container_name` / `k_host`.

## Test plan
- [ ] Flux reconciles `fluent-bit` Kustomization, DaemonSet rolls
- [ ] After ~1 min, in VMUI run: `_stream:{k_container_name=\"grafana\"}` and confirm matches return
- [ ] `_stream:{k_host=~\".+\"} | stats by (k_host) count()` shows a row per node