### PR TITLE
feat(observability): deploy vlogs-vmalert with starter log alerts

### DIFF
--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -20,3 +20,4 @@ resources:
   - ./teslamate/ks.yaml
   - ./karma/ks.yaml
   - ./victoria-logs/ks.yaml
+  - ./vlogs-vmalert/ks.yaml

--- a/kubernetes/apps/observability/vlogs-vmalert/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/vlogs-vmalert/app/helmrelease.yaml
@@ -1,0 +1,122 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vlogs-vmalert
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: vlogs-vmalert
+  interval: 1h
+  values:
+    fullnameOverride: vlogs-vmalert
+    # Point the metrics-shaped flags at VictoriaLogs. The chart wires these into
+    # vmalert's -datasource.url / -remoteRead.url flags; with rule type vlogs the
+    # query path resolves to /select/logsql/stats_query{,_range}.
+    datasource:
+      url: http://victoria-logs-server.observability.svc.cluster.local:9428
+    remoteRead:
+      url: http://victoria-logs-server.observability.svc.cluster.local:9428
+    notifier:
+      url: http://alertmanager-operated.observability.svc.cluster.local:9093
+    extraArgs:
+      rule.defaultRuleType: vlogs
+      external.label: cluster=main
+    serviceMonitor:
+      enabled: true
+    config:
+      alerts:
+        groups:
+          - name: flux.logs
+            interval: 5m
+            type: vlogs
+            rules:
+              - alert: FluxControllerErrorSpike
+                expr: |
+                  _stream:{k_namespace_name="flux-system"} level:error
+                  | stats by (k_container_name) count() as errors
+                  | filter errors:>20
+                for: 0m
+                annotations:
+                  summary: >-
+                    Flux controller {{ $labels.k_container_name }} emitting elevated error rate
+                  description: >-
+                    {{ $value }} error log lines from {{ $labels.k_container_name }} in
+                    flux-system over the last 5m. Check reconciliation status.
+                labels:
+                  severity: warning
+
+          - name: cert-manager.logs
+            interval: 5m
+            type: vlogs
+            rules:
+              - alert: CertManagerErrors
+                expr: |
+                  _stream:{k_namespace_name="cert-manager"} level:error
+                  | stats count() as errors
+                  | filter errors:>5
+                for: 10m
+                annotations:
+                  summary: cert-manager logging persistent errors
+                  description: >-
+                    cert-manager has produced {{ $value }} error lines in the last 5m.
+                    Likely a stuck Order/Challenge or DNS-01 issue.
+                labels:
+                  severity: warning
+
+          - name: external-secrets.logs
+            interval: 5m
+            type: vlogs
+            rules:
+              - alert: ExternalSecretsFailures
+                expr: |
+                  _stream:{k_namespace_name="external-secrets"} _msg:~"(?i)failed|error"
+                  | stats count() as failures
+                  | filter failures:>5
+                for: 10m
+                annotations:
+                  summary: external-secrets-operator failures
+                  description: >-
+                    {{ $value }} failure log lines from external-secrets in the last 5m.
+                    1Password Connect or the secret store may be unreachable.
+                labels:
+                  severity: warning
+
+          - name: logging-pipeline.logs
+            interval: 5m
+            type: vlogs
+            rules:
+              - alert: FluentBitOutputErrors
+                expr: |
+                  _stream:{k_namespace_name="observability", k_container_name="fluent-bit"}
+                  _msg:~"(?i)retry_limit_reached|connection refused|cannot connect"
+                  | stats count() as errors
+                  | filter errors:>5
+                for: 10m
+                annotations:
+                  summary: fluent-bit is failing to ship logs to VictoriaLogs
+                  description: >-
+                    {{ $value }} output errors from fluent-bit in 5m. Logs may be dropping;
+                    check VictoriaLogs availability and fluent-bit DaemonSet health.
+                labels:
+                  severity: critical
+
+          - name: cluster.logs
+            interval: 5m
+            type: vlogs
+            rules:
+              - alert: NamespaceErrorLogStorm
+                expr: |
+                  level:error OR _msg:~"(?i)\\b(panic|fatal|exception)\\b"
+                  | stats by (k_namespace_name) count() as errors
+                  | filter errors:>500
+                for: 10m
+                annotations:
+                  summary: >-
+                    Namespace {{ $labels.k_namespace_name }} is producing an error log storm
+                  description: >-
+                    {{ $value }} error/panic/exception lines in the last 5m. Investigate
+                    which workload is spinning.
+                labels:
+                  severity: warning

--- a/kubernetes/apps/observability/vlogs-vmalert/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/vlogs-vmalert/app/helmrelease.yaml
@@ -11,112 +11,113 @@ spec:
   interval: 1h
   values:
     fullnameOverride: vlogs-vmalert
-    # Point the metrics-shaped flags at VictoriaLogs. The chart wires these into
-    # vmalert's -datasource.url / -remoteRead.url flags; with rule type vlogs the
-    # query path resolves to /select/logsql/stats_query{,_range}.
-    datasource:
-      url: http://victoria-logs-server.observability.svc.cluster.local:9428
-    remoteRead:
-      url: http://victoria-logs-server.observability.svc.cluster.local:9428
-    notifier:
-      url: http://alertmanager-operated.observability.svc.cluster.local:9093
-    extraArgs:
-      rule.defaultRuleType: vlogs
-      external.label: cluster=main
     serviceMonitor:
       enabled: true
-    config:
-      alerts:
-        groups:
-          - name: flux.logs
-            interval: 5m
-            type: vlogs
-            rules:
-              - alert: FluxControllerErrorSpike
-                expr: |
-                  _stream:{k_namespace_name="flux-system"} level:error
-                  | stats by (k_container_name) count() as errors
-                  | filter errors:>20
-                for: 0m
-                annotations:
-                  summary: >-
-                    Flux controller {{ $labels.k_container_name }} emitting elevated error rate
-                  description: >-
-                    {{ $value }} error log lines from {{ $labels.k_container_name }} in
-                    flux-system over the last 5m. Check reconciliation status.
-                labels:
-                  severity: warning
+    server:
+      # Point the metrics-shaped flags at VictoriaLogs. The chart wires these into
+      # vmalert's -datasource.url / -remoteRead.url flags; with rule type vlogs the
+      # query path resolves to /select/logsql/stats_query{,_range}.
+      datasource:
+        url: http://victoria-logs-server.observability.svc.cluster.local:9428
+      remoteRead:
+        url: http://victoria-logs-server.observability.svc.cluster.local:9428
+      notifier:
+        url: http://alertmanager-operated.observability.svc.cluster.local:9093
+      extraArgs:
+        rule.defaultRuleType: vlogs
+        external.label: cluster=main
+      config:
+        alerts:
+          groups:
+            - name: flux.logs
+              interval: 5m
+              type: vlogs
+              rules:
+                - alert: FluxControllerErrorSpike
+                  expr: |
+                    _stream:{k_namespace_name="flux-system"} level:error
+                    | stats by (k_container_name) count() as errors
+                    | filter errors:>20
+                  for: 0m
+                  annotations:
+                    summary: >-
+                      Flux controller {{ $labels.k_container_name }} emitting elevated error rate
+                    description: >-
+                      {{ $value }} error log lines from {{ $labels.k_container_name }} in
+                      flux-system over the last 5m. Check reconciliation status.
+                  labels:
+                    severity: warning
 
-          - name: cert-manager.logs
-            interval: 5m
-            type: vlogs
-            rules:
-              - alert: CertManagerErrors
-                expr: |
-                  _stream:{k_namespace_name="cert-manager"} level:error
-                  | stats count() as errors
-                  | filter errors:>5
-                for: 10m
-                annotations:
-                  summary: cert-manager logging persistent errors
-                  description: >-
-                    cert-manager has produced {{ $value }} error lines in the last 5m.
-                    Likely a stuck Order/Challenge or DNS-01 issue.
-                labels:
-                  severity: warning
+            - name: cert-manager.logs
+              interval: 5m
+              type: vlogs
+              rules:
+                - alert: CertManagerErrors
+                  expr: |
+                    _stream:{k_namespace_name="cert-manager"} level:error
+                    | stats count() as errors
+                    | filter errors:>5
+                  for: 10m
+                  annotations:
+                    summary: cert-manager logging persistent errors
+                    description: >-
+                      cert-manager has produced {{ $value }} error lines in the last 5m.
+                      Likely a stuck Order/Challenge or DNS-01 issue.
+                  labels:
+                    severity: warning
 
-          - name: external-secrets.logs
-            interval: 5m
-            type: vlogs
-            rules:
-              - alert: ExternalSecretsFailures
-                expr: |
-                  _stream:{k_namespace_name="external-secrets"} _msg:~"(?i)failed|error"
-                  | stats count() as failures
-                  | filter failures:>5
-                for: 10m
-                annotations:
-                  summary: external-secrets-operator failures
-                  description: >-
-                    {{ $value }} failure log lines from external-secrets in the last 5m.
-                    1Password Connect or the secret store may be unreachable.
-                labels:
-                  severity: warning
+            - name: external-secrets.logs
+              interval: 5m
+              type: vlogs
+              rules:
+                - alert: ExternalSecretsFailures
+                  expr: |
+                    _stream:{k_namespace_name="external-secrets"} _msg:~"(?i)failed|error"
+                    | stats count() as failures
+                    | filter failures:>5
+                  for: 10m
+                  annotations:
+                    summary: external-secrets-operator failures
+                    description: >-
+                      {{ $value }} failure log lines from external-secrets in the last 5m.
+                      1Password Connect or the secret store may be unreachable.
+                  labels:
+                    severity: warning
 
-          - name: logging-pipeline.logs
-            interval: 5m
-            type: vlogs
-            rules:
-              - alert: FluentBitOutputErrors
-                expr: |
-                  _stream:{k_namespace_name="observability", k_container_name="fluent-bit"}
-                  _msg:~"(?i)retry_limit_reached|connection refused|cannot connect"
-                  | stats count() as errors
-                  | filter errors:>5
-                for: 10m
-                annotations:
-                  summary: fluent-bit is failing to ship logs to VictoriaLogs
-                  description: >-
-                    {{ $value }} output errors from fluent-bit in 5m. Logs may be dropping;
-                    check VictoriaLogs availability and fluent-bit DaemonSet health.
-                labels:
-                  severity: critical
+            - name: logging-pipeline.logs
+              interval: 5m
+              type: vlogs
+              rules:
+                - alert: FluentBitOutputErrors
+                  expr: |
+                    _stream:{k_namespace_name="observability", k_container_name="fluent-bit"}
+                    _msg:~"(?i)retry_limit_reached|connection refused|cannot connect"
+                    | stats count() as errors
+                    | filter errors:>5
+                  for: 10m
+                  annotations:
+                    summary: fluent-bit is failing to ship logs to VictoriaLogs
+                    description: >-
+                      {{ $value }} output errors from fluent-bit in 5m. Logs may be dropping;
+                      check VictoriaLogs availability and fluent-bit DaemonSet health.
+                  labels:
+                    severity: critical
 
-          - name: cluster.logs
-            interval: 5m
-            type: vlogs
-            rules:
-              - alert: NamespaceErrorLogStorm
-                expr: |
-                  level:error OR _msg:~"(?i)\\b(panic|fatal|exception)\\b"
-                  | stats by (k_namespace_name) count() as errors
-                  | filter errors:>500
-                for: 10m
-                annotations:
-                  summary: >-
-                    Namespace {{ $labels.k_namespace_name }} is producing an error log storm
-                  description: >-
-                    {{ $value }} error/panic/exception lines in the last 5m. Investigate
-                    which workload is spinning.
-                labels:
-                  severity: warning
+            - name: cluster.logs
+              interval: 5m
+              type: vlogs
+              rules:
+                - alert: NamespaceErrorLogStorm
+                  expr: |
+                    level:error OR _msg:~"(?i)\\b(panic|fatal|exception)\\b"
+                    | stats by (k_namespace_name) count() as errors
+                    | filter errors:>500
+                  for: 10m
+                  annotations:
+                    summary: >-
+                      Namespace {{ $labels.k_namespace_name }} is producing an error log storm
+                    description: >-
+                      {{ $value }} error/panic/exception lines in the last 5m. Investigate
+                      which workload is spinning.
+                  labels:
+                    severity: warning

--- a/kubernetes/apps/observability/vlogs-vmalert/app/kustomization.yaml
+++ b/kubernetes/apps/observability/vlogs-vmalert/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/observability/vlogs-vmalert/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/vlogs-vmalert/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: vlogs-vmalert
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.40.0
+  url: oci://ghcr.io/victoriametrics/helm-charts/victoria-metrics-alert

--- a/kubernetes/apps/observability/vlogs-vmalert/ks.yaml
+++ b/kubernetes/apps/observability/vlogs-vmalert/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: vlogs-vmalert
+spec:
+  dependsOn:
+    - name: victoria-logs
+      namespace: observability
+    - name: kube-prometheus-stack
+      namespace: observability
+  interval: 1h
+  path: ./kubernetes/apps/observability/vlogs-vmalert/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: observability
+  wait: false


### PR DESCRIPTION
## Summary
- Adds a dedicated `vmalert` instance under `observability/vlogs-vmalert/` configured for `rule.defaultRuleType=vlogs`
- Datasource: in-cluster VictoriaLogs (`victoria-logs-server:9428`)
- Notifier: existing Alertmanager (`alertmanager-operated:9093`) from kube-prometheus-stack
- Ships 5 starter rules; depends on `victoria-logs` and `kube-prometheus-stack` Kustomizations

## Starter ruleset
| Rule | Signal | Severity |
|---|---|---|
| `FluxControllerErrorSpike` | flux-system controllers > 20 error lines / 5m | warning |
| `CertManagerErrors` | cert-manager > 5 error lines / 5m | warning |
| `ExternalSecretsFailures` | external-secrets > 5 \"failed\"/\"error\" lines / 5m | warning |
| `FluentBitOutputErrors` | fluent-bit can't ship to VL | **critical** (meta-alert on the logging pipeline itself) |
| `NamespaceErrorLogStorm` | any namespace > 500 error/panic/fatal/exception lines / 5m | warning |

## Why these signals only
The current logging pipeline (fluent-bit) only ships container stdout/stderr. Kernel-level signals like `OOMKilled` and kubelet-emitted `CrashLoopBackOff` live in node journal/audit, which we don't ship yet. Those are tracked for a follow-up PR that wires Talos `kmsg` / audit logs into VictoriaLogs.

## Tuning expectation
Thresholds are starter values. After a week of running, expect to tune `NamespaceErrorLogStorm` (almost certainly noisy) and probably tighten `CertManagerErrors` (only fires on real Order/Challenge failures, not occasional retry chatter).

## Test plan
- [ ] Flux reconciles the new `vlogs-vmalert` Kustomization
- [ ] `kubectl -n observability get hr vlogs-vmalert` shows Ready
- [ ] vmalert UI shows all 5 groups with `type: vlogs` and rules in `OK` / `Pending` state
- [ ] Trigger a deliberate test (e.g. apply a broken Flux Kustomization) → confirm `FluxControllerErrorSpike` fires
- [ ] Alerts arrive in Alertmanager and route to the configured receivers