### PR TITLE
feat(observability): add Cluster Logs dashboard backed by VictoriaLogs

### DIFF
--- a/kubernetes/apps/observability/grafana/instance/grafanadashboards-victorialogs.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafanadashboards-victorialogs.yaml
@@ -1,0 +1,121 @@
+---
+# Cluster Logs Dashboard - powered by VictoriaLogs.
+# Three rows: overview (rate + by-namespace + by-node), errors (rate, top
+# offenders, recent lines), and drill-down (namespace/container variables).
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: cluster-logs
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasources:
+    - datasourceName: VictoriaLogs
+      inputName: DS_VICTORIALOGS
+  json: |
+    {
+      "title": "Cluster Logs",
+      "uid": "cluster-logs",
+      "schemaVersion": 39,
+      "version": 1,
+      "editable": true,
+      "tags": ["logs", "victorialogs"],
+      "time": { "from": "now-1h", "to": "now" },
+      "refresh": "30s",
+      "timepicker": {},
+      "templating": {
+        "list": [
+          {
+            "name": "namespace",
+            "label": "Namespace",
+            "type": "query",
+            "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+            "query": { "expr": "* | stats by (k_namespace_name) count() | keep k_namespace_name", "type": "stats" },
+            "refresh": 2,
+            "includeAll": true,
+            "multi": true,
+            "current": { "selected": true, "text": "All", "value": "$__all" }
+          },
+          {
+            "name": "container",
+            "label": "Container",
+            "type": "query",
+            "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+            "query": { "expr": "_stream:{k_namespace_name=~\"$namespace\"} | stats by (k_container_name) count() | keep k_container_name", "type": "stats" },
+            "refresh": 2,
+            "includeAll": true,
+            "multi": true,
+            "current": { "selected": true, "text": "All", "value": "$__all" }
+          }
+        ]
+      },
+      "panels": [
+        {
+          "id": 1, "type": "row", "title": "Overview",
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }, "collapsed": false
+        },
+        {
+          "id": 2, "type": "stat", "title": "Log rate (last 5m)",
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+          "targets": [{ "expr": "_time:5m | stats count() as count", "refId": "A", "queryType": "stats" }],
+          "gridPos": { "h": 6, "w": 6, "x": 0, "y": 1 },
+          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "graphMode": "area" }
+        },
+        {
+          "id": 3, "type": "barchart", "title": "Logs by namespace (last 1h)",
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+          "targets": [{ "expr": "_time:1h | stats by (k_namespace_name) count() as logs | sort by (logs desc) | limit 15", "refId": "A", "queryType": "stats" }],
+          "gridPos": { "h": 8, "w": 12, "x": 6, "y": 1 },
+          "fieldConfig": { "defaults": { "custom": { "orientation": "horizontal" } } }
+        },
+        {
+          "id": 4, "type": "barchart", "title": "Logs by node (last 1h)",
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+          "targets": [{ "expr": "_time:1h | stats by (k_host) count() as logs | sort by (logs desc)", "refId": "A", "queryType": "stats" }],
+          "gridPos": { "h": 8, "w": 6, "x": 18, "y": 1 },
+          "fieldConfig": { "defaults": { "custom": { "orientation": "horizontal" } } }
+        },
+        {
+          "id": 10, "type": "row", "title": "Errors",
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 }, "collapsed": false
+        },
+        {
+          "id": 11, "type": "timeseries", "title": "Error log rate by namespace",
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+          "targets": [{ "expr": "level:error OR _msg:~\"(?i)\\\\b(error|exception|panic|fatal)\\\\b\" | stats by (k_namespace_name) count()", "refId": "A", "queryType": "stats" }],
+          "gridPos": { "h": 9, "w": 16, "x": 0, "y": 10 }
+        },
+        {
+          "id": 12, "type": "table", "title": "Top 10 noisiest error sources (last 1h)",
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+          "targets": [{ "expr": "_time:1h level:error OR _msg:~\"(?i)\\\\b(error|exception|panic|fatal)\\\\b\" | stats by (k_namespace_name, k_container_name) count() as errors | sort by (errors desc) | limit 10", "refId": "A", "queryType": "stats" }],
+          "gridPos": { "h": 9, "w": 8, "x": 16, "y": 10 }
+        },
+        {
+          "id": 13, "type": "logs", "title": "Recent error lines (last 15m)",
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+          "targets": [{ "expr": "_time:15m level:error OR _msg:~\"(?i)\\\\b(error|exception|panic|fatal)\\\\b\"", "refId": "A", "queryType": "logs", "maxLines": 200 }],
+          "gridPos": { "h": 12, "w": 24, "x": 0, "y": 19 },
+          "options": { "showTime": true, "wrapLogMessage": true, "dedupStrategy": "none", "sortOrder": "Descending" }
+        },
+        {
+          "id": 20, "type": "row", "title": "Drill-down ($namespace / $container)",
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 31 }, "collapsed": false
+        },
+        {
+          "id": 21, "type": "timeseries", "title": "Log rate for selection",
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+          "targets": [{ "expr": "_stream:{k_namespace_name=~\"$namespace\", k_container_name=~\"$container\"} | stats by (k_container_name) count()", "refId": "A", "queryType": "stats" }],
+          "gridPos": { "h": 8, "w": 24, "x": 0, "y": 32 }
+        },
+        {
+          "id": 22, "type": "logs", "title": "Live logs for selection (last 15m)",
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+          "targets": [{ "expr": "_time:15m _stream:{k_namespace_name=~\"$namespace\", k_container_name=~\"$container\"}", "refId": "A", "queryType": "logs", "maxLines": 500 }],
+          "gridPos": { "h": 16, "w": 24, "x": 0, "y": 40 },
+          "options": { "showTime": true, "wrapLogMessage": true, "dedupStrategy": "none", "sortOrder": "Descending" }
+        }
+      ]
+    }

--- a/kubernetes/apps/observability/grafana/instance/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana/instance/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - ./grafanadatasource.yaml
   - ./grafanafolders.yaml
   - ./grafanadashboards.yaml
+  - ./grafanadashboards-victorialogs.yaml
   - ./httproute.yaml
   - ./servicemonitor.yaml


### PR DESCRIPTION
## Summary
- New `GrafanaDashboard` CR: **Cluster Logs** (uid `cluster-logs`)
- One dashboard, three rows:
  - **Overview** — log rate (5m stat), logs-by-namespace bar chart (1h), logs-by-node bar chart (1h)
  - **Errors** — error rate timeseries by namespace, top 10 noisy error sources table (1h), recent error log lines (15m)
  - **Drill-down** — `$namespace` + `$container` template variables driving a per-selection log-rate timeseries and a live log panel
- Wired into `grafana/instance/kustomization.yaml`

## Dependencies (merge order)
1. #2602 — VictoriaLogs datasource (creates the `victorialogs` uid this dashboard targets)
2. #2604 — fluent-bit container/host stream fields (the by-node bar chart and `$container` variable rely on them)
3. This PR

Mergeable today, but the by-node panel and drill-down will be empty until #2604 lands and a few minutes of logs have been ingested with the new keying.

## Tuning expectation
LogsQL details (especially the regex for error detection and the `level:` field which only some apps emit) are starter values — expect to refine in-UI once you see what your actual log corpus looks like. Editable in Grafana is on; persist changes via export → update YAML.

## Test plan
- [ ] Flux reconciles `grafana` Kustomization
- [ ] Dashboard appears in Grafana → Dashboards → \"Cluster Logs\"
- [ ] All 11 panels render data (some may be empty if dependent PRs haven't merged yet)
- [ ] Changing `$namespace` and `$container` filters the bottom two panels