### PR TITLE
fix(observability): make Cluster Logs dashboard panels render

### DIFF
--- a/kubernetes/apps/observability/grafana/instance/grafanadashboards-victorialogs.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafanadashboards-victorialogs.yaml
@@ -19,7 +19,7 @@ spec:
       "title": "Cluster Logs",
       "uid": "cluster-logs",
       "schemaVersion": 39,
-      "version": 1,
+      "version": 2,
       "editable": true,
       "tags": ["logs", "victorialogs"],
       "time": { "from": "now-1h", "to": "now" },
@@ -32,9 +32,10 @@ spec:
             "label": "Namespace",
             "type": "query",
             "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
-            "query": { "expr": "* | stats by (k_namespace_name) count() | keep k_namespace_name", "type": "stats" },
+            "query": { "type": "fieldValue", "field": "k_namespace_name", "limit": 1000 },
             "refresh": 2,
             "includeAll": true,
+            "allValue": ".+",
             "multi": true,
             "current": { "selected": true, "text": "All", "value": "$__all" }
           },
@@ -43,9 +44,10 @@ spec:
             "label": "Container",
             "type": "query",
             "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
-            "query": { "expr": "_stream:{k_namespace_name=~\"$namespace\"} | stats by (k_container_name) count() | keep k_container_name", "type": "stats" },
+            "query": { "type": "fieldValue", "field": "k_container_name", "query": "{k_namespace_name=~\"$namespace\"}", "limit": 1000 },
             "refresh": 2,
             "includeAll": true,
+            "allValue": ".+",
             "multi": true,
             "current": { "selected": true, "text": "All", "value": "$__all" }
           }
@@ -84,19 +86,19 @@ spec:
         {
           "id": 11, "type": "timeseries", "title": "Error log rate by namespace",
           "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
-          "targets": [{ "expr": "level:error OR _msg:~\"(?i)\\\\b(error|exception|panic|fatal)\\\\b\" | stats by (k_namespace_name) count()", "refId": "A", "queryType": "stats" }],
+          "targets": [{ "expr": "_msg:~\"(?i)error|exception|panic|fatal\" | stats by (k_namespace_name) count()", "refId": "A", "queryType": "statsRange" }],
           "gridPos": { "h": 9, "w": 16, "x": 0, "y": 10 }
         },
         {
           "id": 12, "type": "table", "title": "Top 10 noisiest error sources (last 1h)",
           "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
-          "targets": [{ "expr": "_time:1h level:error OR _msg:~\"(?i)\\\\b(error|exception|panic|fatal)\\\\b\" | stats by (k_namespace_name, k_container_name) count() as errors | sort by (errors desc) | limit 10", "refId": "A", "queryType": "stats" }],
+          "targets": [{ "expr": "_time:1h _msg:~\"(?i)error|exception|panic|fatal\" | stats by (k_namespace_name, k_container_name) count() as errors | sort by (errors desc) | limit 10", "refId": "A", "queryType": "stats" }],
           "gridPos": { "h": 9, "w": 8, "x": 16, "y": 10 }
         },
         {
           "id": 13, "type": "logs", "title": "Recent error lines (last 15m)",
           "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
-          "targets": [{ "expr": "_time:15m level:error OR _msg:~\"(?i)\\\\b(error|exception|panic|fatal)\\\\b\"", "refId": "A", "queryType": "logs", "maxLines": 200 }],
+          "targets": [{ "expr": "_time:15m _msg:~\"(?i)error|exception|panic|fatal\"", "refId": "A", "queryType": "instant", "maxLines": 200 }],
           "gridPos": { "h": 12, "w": 24, "x": 0, "y": 19 },
           "options": { "showTime": true, "wrapLogMessage": true, "dedupStrategy": "none", "sortOrder": "Descending" }
         },
@@ -107,13 +109,13 @@ spec:
         {
           "id": 21, "type": "timeseries", "title": "Log rate for selection",
           "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
-          "targets": [{ "expr": "_stream:{k_namespace_name=~\"$namespace\", k_container_name=~\"$container\"} | stats by (k_container_name) count()", "refId": "A", "queryType": "stats" }],
+          "targets": [{ "expr": "{k_namespace_name=~\"$namespace\", k_container_name=~\"$container\"} | stats by (k_container_name) count()", "refId": "A", "queryType": "statsRange" }],
           "gridPos": { "h": 8, "w": 24, "x": 0, "y": 32 }
         },
         {
           "id": 22, "type": "logs", "title": "Live logs for selection (last 15m)",
           "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
-          "targets": [{ "expr": "_time:15m _stream:{k_namespace_name=~\"$namespace\", k_container_name=~\"$container\"}", "refId": "A", "queryType": "logs", "maxLines": 500 }],
+          "targets": [{ "expr": "_time:15m {k_namespace_name=~\"$namespace\", k_container_name=~\"$container\"}", "refId": "A", "queryType": "instant", "maxLines": 500 }],
           "gridPos": { "h": 16, "w": 24, "x": 0, "y": 40 },
           "options": { "showTime": true, "wrapLogMessage": true, "dedupStrategy": "none", "sortOrder": "Descending" }
         }


### PR DESCRIPTION
## Summary
Four of the eight data panels on the Cluster Logs dashboard (added in #2606) were rendering empty. This PR fixes both root causes I found while validating on the live cluster.

## Bug 1 — Template variable queries (drill-down panels empty)
PR #2606 used a homemade variable query shape `{ expr, type }`. The VictoriaLogs Grafana plugin's variable resolver expects:

```json
{ "type": "fieldValue", "field": "k_namespace_name", "limit": 1000 }
```

Result: the `\$namespace` and `\$container` dropdowns never populated, the URL stayed at the literal `var-namespace=\$__all`, and `=~"\$__all"` matched nothing in the two drill-down panels.

Also added `"allValue": ".+"` so the **All** selection expands to a regex that matches every value rather than the literal `\$__all`.

## Bug 2 — Timeseries panels used the wrong queryType
The plugin's enum is `instant | stats | statsRange | hits`. The `stats` type calls `/select/logsql/stats_query` which returns a single scalar — fine for a stat panel, useless for a timeseries.

Changes:
- panel 11 (`Error log rate by namespace`, timeseries): `stats` → `statsRange`
- panel 21 (`Log rate for selection`, timeseries): `stats` → `statsRange`
- panels 13 + 22 (logs panels): `logs` → `instant` (matches the documented enum)

## Bonus — Error-detection LogsQL simplified
The original `level:error OR _msg:~"(?i)\\b(error|exception|panic|fatal)\\b"` had two problems:
1. fluent-bit's `kubernetes` filter doesn't extract a `level` field, so `level:error` matched zero logs and the top-level `OR` with a regex confused the LogsQL parser.
2. `\b` word boundaries excluded common forms like `failed_to_start`.

Replaced with `_msg:~"(?i)error|exception|panic|fatal"` — a simple substring regex match. Verified against live VL: returns 2622 entries from observability/app, 1057 from kube-apiserver, etc.

## Test plan
Tested each rewritten query against live VL through the datasource proxy:
- [x] \`fieldValue\` variable query returns all 12 namespaces
- [x] `statsRange` timeseries query returns per-namespace error rate over time
- [x] simplified error regex catches lines `level:error` would have missed
- [x] drill-down query with `\$__all → .+` matches all logs
- [ ] after merge, take a screenshot of the dashboard and confirm all 8 data panels show content