### PR TITLE
fix(observability): keep prometheus off rook-ceph-mgr nodes

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -112,6 +112,15 @@ spec:
               resources:
                 requests:
                   storage: 50Gi
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchLabels:
+                      app: rook-ceph-mgr
+                  topologyKey: kubernetes.io/hostname
     kubelet:
       enabled: true
       serviceMonitor:


### PR DESCRIPTION
## Summary

Soft `podAntiAffinity` prevents Prometheus from co-locating with `rook-ceph-mgr` pods.

## Why

Investigation of cluster instability found that **kube-apiserver on k8s-2 was panicking 17×/hour** with etcd context-deadline-exceeded errors. Root cause was CPU/memory contention during Prometheus scrape bursts when co-located with the active `rook-ceph-mgr` on k8s-2.

### Evidence
- etcd k8s-2: `apply request took too long` warnings up to **1.04 seconds** (vs 100ms expected)
- etcd k8s-2: `ReadIndex response took too long, retrying`, `local node read indexes queueing up`
- k8s-2 CPU package temperature: **79°C spike** vs 46–48°C on k8s-1/k8s-3 during the same window
- After manually rescheduling Prometheus to k8s-1 and failing the active Ceph mgr to k8s-3:
  - 0 apiserver panics in following 10 min
  - 0 new etcd health check failures
  - k8s-2 temperature aligned at 49°C
  - k8s-2 memory dropped from 19.3 GB (31%) to 16.4 GB (26%)

## How

With 2 mgr pods spread across 2 nodes, Prometheus will prefer the third node (currently k8s-1). Kept `preferredDuringScheduling` (soft) so Prometheus can still fall back to a Ceph-mgr node if one of the other two control planes is unavailable.

## Test plan

- [x] YAML validates with `python3 -m yaml`
- [x] Affinity block lands under `prometheus.prometheusSpec.affinity` (correct kube-prometheus-stack path)
- [ ] After merge, watch Flux reconcile and confirm Prometheus stays off the node hosting active rook-ceph-mgr
- [ ] Re-check etcd events on k8s-2 over 24h — expect zero new `Health check failed` events