### PR TITLE
fix(observability): resolve kube-prometheus-stack HelmRelease upgrade failure

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -112,6 +112,10 @@ spec:
               resources:
                 requests:
                   storage: 50Gi
+        # Disable chart's auto-generated podAntiAffinity (default "soft")
+        # which would render a second podAntiAffinity key alongside ours.
+        # We only have 1 prometheus replica so the self-spread is moot.
+        podAntiAffinity: ""
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Summary

Follow-up to #2611. That PR added `prometheus.prometheusSpec.affinity` but kube-prometheus-stack chart 85.0.2 still rendered its built-in `podAntiAffinity` (default `"soft"`) alongside ours, producing **two `podAntiAffinity` keys** under the same `affinity:` mapping in the Prometheus CR. Helm post-render then failed:

```
yaml: unmarshal errors:
  line 87: mapping key "podAntiAffinity" already defined at line 79
```

## Root cause

Chart template `templates/prometheus/prometheus.yaml` (lines 316–337):

```gotmpl
{{- if or .Values.prometheus.prometheusSpec.podAntiAffinity .Values.prometheus.prometheusSpec.affinity }}
  affinity:
{{- if .Values.prometheus.prometheusSpec.affinity }}
{{ toYaml .Values.prometheus.prometheusSpec.affinity | indent 4 }}
{{- end }}
{{- if eq .Values.prometheus.prometheusSpec.podAntiAffinity "hard" }}
    podAntiAffinity: …
{{- else if eq .Values.prometheus.prometheusSpec.podAntiAffinity "soft" }}
    podAntiAffinity: …
{{- end }}
{{- end }}
```

Both branches render whenever `affinity` is set AND `podAntiAffinity` matches `"soft"`/`"hard"`. The chart treats them as additive, not mutually exclusive.

## Fix

Set `prometheus.prometheusSpec.podAntiAffinity: ""` to disable the chart's auto-generated block. Our custom `affinity:` is the only one rendered.

The chart's `"soft"` default was a single-replica self-spread (Prometheus replicas across nodes). We run 1 replica, so that's a no-op anyway.

## Verification

Reproduced locally with `helm template` against chart 85.0.2:

- **Before fix**: 2 `podAntiAffinity` keys under `affinity:` ❌
- **After fix**: 1 key (rook-ceph-mgr antiaffinity only) ✅

## Test plan

- [x] Repro confirmed locally with `helm template`
- [x] Fix validated locally with `helm template`
- [ ] After merge: Flux HelmRelease `observability/kube-prometheus-stack` recovers `Ready=True`
- [ ] After merge: Prometheus pod still scheduled on a non-`rook-ceph-mgr` node (currently k8s-1)