### PR TITLE
fix(cloudnative-pg): pin operator image to 1.29.0

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/app/helmrelease.yaml
@@ -30,6 +30,10 @@ spec:
       strategy: rollback
       retries: 3
   values:
+    image:
+      # Pinned to 1.29.0 due to 1.29.1 startup hang in ensurePKI() — see upstream #10679.
+      # Remove this pin once 1.29.2 ships and is verified working.
+      tag: 1.29.0
     crds:
       create: true
     monitoring:


### PR DESCRIPTION
## Summary
- Pin the cloudnative-pg operator image to `1.29.0` while keeping chart `0.28.2`.
- `1.29.1` silently hangs during startup after `Kubernetes system metadata` log (in `ensurePKI()`), so the webhook server on `:9443` never binds, the kubelet startup probe (30s window) keeps killing the container, and the pod has been crashlooping for ~3 days (91 restarts).
- Upstream tracks 1.29.1 regressions in [#10679](https://github.com/cloudnative-pg/cloudnative-pg/issues/10679), [#10680](https://github.com/cloudnative-pg/cloudnative-pg/issues/10680), [#10675](https://github.com/cloudnative-pg/cloudnative-pg/issues/10675). A maintainer-suggested workaround on #10679 is exactly this: keep the new chart but pin operator image to 1.29.0.

The `postgres16` cluster has stayed healthy throughout (the operator updates Cluster status before crashing), but no new reconciles have been happening.

## Test plan
- [ ] Merge → Flux reconciles HelmRelease → new pod rolls out
- [ ] `kubectl -n databases get pod -l app.kubernetes.io/name=cloudnative-pg -w` shows the new pod reach `Ready 1/1`
- [ ] `kubectl -n databases logs <new-pod>` shows `starting manager` and webhook server bind to `:9443`
- [ ] `kubectl -n databases get cluster postgres16` still `Cluster in healthy state`
- [ ] Once 1.29.2 ships and is verified, drop the `image.tag` pin (and let Renovate take over again)