### PR TITLE
fix(rook-ceph): move cephfs kernelMountOptions to CephCluster spec.csi

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
@@ -19,7 +19,6 @@ spec:
       retries: 3
   values:
     csi:
-      cephFSKernelMountOptions: ms_mode=prefer-crc
       enableLiveness: true
       serviceMonitor:
         enabled: true

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -53,6 +53,10 @@ spec:
       crashCollector:
         disable: false
       csi:
+        cephfs:
+          # rook v1.20 chart dropped csi.cephFSKernelMountOptions; without ms_mode
+          # the kernel client speaks msgr1 on the msgr2 port (3300) and mounts fail
+          kernelMountOptions: ms_mode=prefer-crc
         readAffinity:
           enabled: true
       dashboard:


### PR DESCRIPTION
## Problème

Après le rolling upgrade Talos v1.13.4, tous les nouveaux montages CephFS échouent :

```
libceph: mon1 (1)192.168.10.11:3300 socket closed (con state V1_BANNER)
mount error: no mds (Metadata Server) is up
```

Le client kernel parle msgr1 sur le port msgr2 (3300, `requireMsgr2: true`) car l'option `ms_mode=prefer-crc` n'est plus injectée.

## Cause

Le chart rook v1.20 a supprimé `csi.cephFSKernelMountOptions` (migration ceph-csi-operator) — la valeur du repo était ignorée silencieusement et les `ClientProfile` générés n'ont aucun `kernelMountOptions`. Les reboots de l'upgrade Talos ont forcé des remontages frais, exposant le problème (pods billionmail bloqués en ContainerCreating).

## Fix

Déplace l'option vers `cephClusterSpec.csi.cephfs.kernelMountOptions`, le nouvel emplacement supporté, et retire l'ancienne valeur morte du chart operator.