### PR TITLE
fix(kubernetes): bump control plane and kubelet to v1.36.1, track with renovate

### DIFF
--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -66,7 +66,8 @@ machine:
       serializeImagePulls: false
       imageGCHighThresholdPercent: 60
       imageGCLowThresholdPercent: 50
-    image: ghcr.io/siderolabs/kubelet:v1.36.0
+    # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
+    image: ghcr.io/siderolabs/kubelet:v1.36.1
     nodeIP:
       validSubnets:
         - 192.168.10.0/24
@@ -150,11 +151,13 @@ cluster:
       enable-aggregator-routing: "true"
       feature-gates: ImageVolume=true,MutatingAdmissionPolicy=true
       runtime-config: admissionregistration.k8s.io/v1beta1=true
-    image: registry.k8s.io/kube-apiserver:v1.36.0
+    # renovate: datasource=docker depName=registry.k8s.io/kube-apiserver
+    image: registry.k8s.io/kube-apiserver:v1.36.1
   controllerManager:
     extraArgs:
       bind-address: 0.0.0.0
-    image: registry.k8s.io/kube-controller-manager:v1.36.0
+    # renovate: datasource=docker depName=registry.k8s.io/kube-controller-manager
+    image: registry.k8s.io/kube-controller-manager:v1.36.1
   coreDNS:
     disabled: true
   etcd:
@@ -188,7 +191,8 @@ cluster:
                 - name: ImageLocality
     extraArgs:
       bind-address: 0.0.0.0
-    image: registry.k8s.io/kube-scheduler:v1.36.0
+    # renovate: datasource=docker depName=registry.k8s.io/kube-scheduler
+    image: registry.k8s.io/kube-scheduler:v1.36.1
   secretboxEncryptionSecret: op://kubernetes/talos/CLUSTER_SECRETBOXENCRYPTIONSECRET
   serviceAccount:
     key: op://kubernetes/talos/CLUSTER_SERVICEACCOUNT_KEY


### PR DESCRIPTION
The SUC kubernetes plan upgraded to v1.36.1 on May 13 but the
machineconfig template still pinned v1.36.0, so the May 27
apply-config (scheduler panic fix) reverted the cluster to v1.36.0
while the plan stayed marked Complete. Add renovate comments so the
template and the SUC plan can no longer drift apart (same failure
mode as the stuck v1.35.1 upgrade fixed in d2d74b1c).
