### PR TITLE
fix(metrics-server): add matchOIDCIdentity to cosign verification

### DIFF
--- a/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml
@@ -14,6 +14,9 @@ spec:
   url: oci://ghcr.io/home-operations/charts-mirror/metrics-server
   verify:
     provider: cosign
+    matchOIDCIdentity:
+      - issuer: ^https://token.actions.githubusercontent.com$
+        subject: ^https://github.com/home-operations/charts-mirror.*$
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2


### PR DESCRIPTION
Newer source-controller (came with flux-operator 0.51.0) refuses
keyless cosign verification without at least one identity, blocking
the chart fetch. Identity taken from the charts-mirror docs.
