### PR TITLE
fix(blackbox-exporter): update pi-hole probe targets to ethernet IPs

### DIFF
--- a/kubernetes/apps/observability/blackbox-exporter/app/probes.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/probes.yaml
@@ -17,8 +17,8 @@ spec:
         - zigbee-controller.g-eye.tech
         - 192.168.10.2 # haproxy1
         - 192.168.10.3 # haproxy2
-        - 192.168.0.197 # pi-hole1
-        - 192.168.0.214 # pi-hole2
+        - 192.168.0.196 # pi-hole1
+        - 192.168.0.212 # pi-hole2
       relabelingConfigs:
         # Strip *.g-eye.tech suffix so hostnames become friendly names
         - sourceLabels: [instance]
@@ -35,11 +35,11 @@ spec:
           targetLabel: name
           replacement: haproxy2
         - sourceLabels: [instance]
-          regex: 192\.168\.0\.197
+          regex: 192\.168\.0\.196
           targetLabel: name
           replacement: pi-hole1
         - sourceLabels: [instance]
-          regex: 192\.168\.0\.214
+          regex: 192\.168\.0\.212
           targetLabel: name
           replacement: pi-hole2
 ---
@@ -69,5 +69,5 @@ spec:
   targets:
     staticConfig:
       static:
-        - 192.168.0.197:53 # pi-hole1 dns
-        - 192.168.0.214:53 # pi-hole2 dns
+        - 192.168.0.196:53 # pi-hole1 dns
+        - 192.168.0.212:53 # pi-hole2 dns


### PR DESCRIPTION
WiFi was disabled on both pi-holes; the blackbox probes still targeted the old WiFi DHCP IPs (`192.168.0.197` / `192.168.0.214`), causing 4 `BlackboxProbeFailed` alerts (ICMP + DNS per host).

This updates the ICMP and DNS probe targets and the relabeling regexes to the static ethernet IPs (`192.168.0.196` / `192.168.0.212`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)