### PR TITLE
fix(gatus): quote templated DNS query names

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -80,7 +80,7 @@ spec:
             gatus.home-operations.com/endpoint: |-
               conditions: ["len([BODY]) == 0"]
               dns:
-                query-name: {{ .Release.Name }}.g-eye.io
+                query-name: "{{ .Release.Name }}.g-eye.io"
                 query-type: A
               url: 1.1.1.1
           hostnames: ["prometheus.g-eye.io"]

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -30,7 +30,7 @@ spec:
           gatus.home-operations.com/endpoint: |-
             conditions: ["len([BODY]) == 0"]
             dns:
-              query-name: {{ .Release.Name }}.g-eye.io
+              query-name: "{{ .Release.Name }}.g-eye.io"
               query-type: A
             url: 1.1.1.1
         host:


### PR DESCRIPTION
## Summary
- quote templated gatus-sidecar DNS query names in endpoint annotations
- fixes YAML decoding errors for the Prometheus and Rook Ceph dashboard HTTPRoutes after the gatus-sidecar 0.2.1 rollout

## Validation
- python3 yaml.safe_load_all on changed files
- git diff --check