### PR TITLE
fix(volsync): stagger ReplicationSource schedules to avoid synchronized hourly IO storm

### DIFF
--- a/kubernetes/apps/databases/pgadmin/ks.yaml
+++ b/kubernetes/apps/databases/pgadmin/ks.yaml
@@ -19,6 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "32"
       VOLSYNC_CAPACITY: 5Gi
   prune: true
   retryInterval: 2m

--- a/kubernetes/apps/default/atuin/ks.yaml
+++ b/kubernetes/apps/default/atuin/ks.yaml
@@ -19,6 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "0"
       GATUS_SUBDOMAIN: sh
       VOLSYNC_CAPACITY: 5Gi
   prune: true

--- a/kubernetes/apps/default/bazarr/ks.yaml
+++ b/kubernetes/apps/default/bazarr/ks.yaml
@@ -19,6 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "2"
       VOLSYNC_CAPACITY: 5Gi
   prune: true
   retryInterval: 2m

--- a/kubernetes/apps/default/billionmail/ks.yaml
+++ b/kubernetes/apps/default/billionmail/ks.yaml
@@ -26,6 +26,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "5"
       VOLSYNC_CAPACITY: 5Gi
   prune: true
   retryInterval: 2m

--- a/kubernetes/apps/default/changedetection/ks.yaml
+++ b/kubernetes/apps/default/changedetection/ks.yaml
@@ -19,6 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "7"
       VOLSYNC_CAPACITY: 1Gi
   prune: true
   retryInterval: 2m

--- a/kubernetes/apps/default/fusion/ks.yaml
+++ b/kubernetes/apps/default/fusion/ks.yaml
@@ -19,6 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "9"
       VOLSYNC_CAPACITY: 1Gi
   prune: true
   retryInterval: 2m

--- a/kubernetes/apps/default/jellyseerr/ks.yaml
+++ b/kubernetes/apps/default/jellyseerr/ks.yaml
@@ -19,6 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "14"
       GATUS_PATH: /api/v1/status
       GATUS_SUBDOMAIN: requests
       VOLSYNC_CAPACITY: 5Gi

--- a/kubernetes/apps/default/karakeep/ks.yaml
+++ b/kubernetes/apps/default/karakeep/ks.yaml
@@ -21,6 +21,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "16"
       VOLSYNC_CAPACITY: 1Gi
   prune: true
   retryInterval: 2m

--- a/kubernetes/apps/default/kometa/ks.yaml
+++ b/kubernetes/apps/default/kometa/ks.yaml
@@ -19,6 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "18"
       VOLSYNC_CAPACITY: 30Gi
   prune: true
   retryInterval: 2m

--- a/kubernetes/apps/default/lelabo-crm/ks.yaml
+++ b/kubernetes/apps/default/lelabo-crm/ks.yaml
@@ -30,4 +30,5 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "21"
       VOLSYNC_CAPACITY: 5Gi

--- a/kubernetes/apps/default/n8n/ks.yaml
+++ b/kubernetes/apps/default/n8n/ks.yaml
@@ -16,6 +16,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "23"
       VOLSYNC_CAPACITY: 1Gi
   prune: true
   retryInterval: 2m

--- a/kubernetes/apps/default/open-webui/ks.yaml
+++ b/kubernetes/apps/default/open-webui/ks.yaml
@@ -29,4 +29,5 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "25"
       VOLSYNC_CAPACITY: 5Gi

--- a/kubernetes/apps/default/openclaw/instances/openclaw/ks.yaml
+++ b/kubernetes/apps/default/openclaw/instances/openclaw/ks.yaml
@@ -21,6 +21,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "28"
       VOLSYNC_CAPACITY: 15Gi
   prune: true
   retryInterval: 2m

--- a/kubernetes/apps/default/paperless-ai/ks.yaml
+++ b/kubernetes/apps/default/paperless-ai/ks.yaml
@@ -21,6 +21,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "30"
   prune: true
   retryInterval: 1m
   sourceRef:

--- a/kubernetes/apps/default/plex/ks.yaml
+++ b/kubernetes/apps/default/plex/ks.yaml
@@ -22,6 +22,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "35"
       GATUS_PATH: /web/index.html
       VOLSYNC_CAPACITY: 50Gi
   prune: true

--- a/kubernetes/apps/default/prowlarr/ks.yaml
+++ b/kubernetes/apps/default/prowlarr/ks.yaml
@@ -22,6 +22,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "37"
       VOLSYNC_CAPACITY: 1Gi
   prune: true
   retryInterval: 2m

--- a/kubernetes/apps/default/radarr/ks.yaml
+++ b/kubernetes/apps/default/radarr/ks.yaml
@@ -22,6 +22,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "39"
       VOLSYNC_CAPACITY: 5Gi
   prune: true
   retryInterval: 2m

--- a/kubernetes/apps/default/recommendarr/ks.yaml
+++ b/kubernetes/apps/default/recommendarr/ks.yaml
@@ -18,6 +18,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "42"
   prune: true
   retryInterval: 1m
   sourceRef:

--- a/kubernetes/apps/default/recyclarr/ks.yaml
+++ b/kubernetes/apps/default/recyclarr/ks.yaml
@@ -19,6 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "44"
       VOLSYNC_CAPACITY: 1Gi
   prune: true
   retryInterval: 2m

--- a/kubernetes/apps/default/rybbit/ks.yaml
+++ b/kubernetes/apps/default/rybbit/ks.yaml
@@ -30,4 +30,5 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "46"
       VOLSYNC_CAPACITY: 200Gi

--- a/kubernetes/apps/default/sabnzbd/ks.yaml
+++ b/kubernetes/apps/default/sabnzbd/ks.yaml
@@ -19,6 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "48"
       GATUS_SUBDOMAIN: sab
       VOLSYNC_CAPACITY: 1Gi
   prune: true

--- a/kubernetes/apps/default/sonarr/ks.yaml
+++ b/kubernetes/apps/default/sonarr/ks.yaml
@@ -22,6 +22,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "51"
       VOLSYNC_CAPACITY: 5Gi
   prune: true
   retryInterval: 2m

--- a/kubernetes/apps/default/tautulli/ks.yaml
+++ b/kubernetes/apps/default/tautulli/ks.yaml
@@ -22,6 +22,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "53"
       VOLSYNC_CAPACITY: 5Gi
   prune: true
   retryInterval: 2m

--- a/kubernetes/apps/default/twenty/ks.yaml
+++ b/kubernetes/apps/default/twenty/ks.yaml
@@ -28,4 +28,5 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "58"
       VOLSYNC_CAPACITY: 5Gi

--- a/kubernetes/apps/dev/gitea/ks.yaml
+++ b/kubernetes/apps/dev/gitea/ks.yaml
@@ -19,6 +19,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "12"
       VOLSYNC_CAPACITY: 10Gi
   prune: true
   retryInterval: 1m

--- a/kubernetes/apps/observability/teslamate/ks.yaml
+++ b/kubernetes/apps/observability/teslamate/ks.yaml
@@ -25,6 +25,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_SCHEDULE_MINUTE: "55"
       VOLSYNC_CAPACITY: 5Gi
   prune: true
   retryInterval: 2m

--- a/kubernetes/components/volsync/replicationsource.yaml
+++ b/kubernetes/components/volsync/replicationsource.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   sourcePVC: ${APP}
   trigger:
-    schedule: 0 * * * *
+    schedule: "${VOLSYNC_SCHEDULE_MINUTE:=0} * * * *"
   kopia:
     accessModes:
       - ${VOLSYNC_SNAP_ACCESSMODES:=ReadWriteOnce}


### PR DESCRIPTION
## Problème

Les **25 ReplicationSources VolSync** étaient toutes sur le cron `0 * * * *` (codé en dur dans le composant partagé `components/volsync/replicationsource.yaml`). Elles déclenchaient leurs backups kopia **simultanément en tête de chaque heure** → orage d'IO/fsync synchronisé sur les 3 nœuds (chacun héberge un OSD Ceph).

Cet orage affamait le disque etcd — pire sur **k8s-2 (.12)** — poussant le backend-commit p99 à **240–400ms** (budget <25ms) et faisant brûler le SLO de latence de l'apiserver → alerte **`KubeAPIErrorBudgetBurn`** (warning, 3d/6h).

Diagnostic : ~82% du burn = latence (pas erreurs, 5xx réel 0.07%), tiers critiques inactifs, condition chronique. RCA vérifié par analyse multi-angle adversariale.

## Changement

- Composant : `schedule: 0 * * * *` → `schedule: "\${VOLSYNC_SCHEDULE_MINUTE:=0} * * * *"` (défaut `0` → rétro-compatible pour toute app non surchargée).
- 26 `ks.yaml` : `VOLSYNC_SCHEDULE_MINUTE` distinct par app, réparti uniformément 0→58 (~2,3 min d'écart) → au plus ~1–2 movers concurrents.

## Effet

Supprime le pic d'IO horaire synchronisé. **Ne corrige pas** la fragilité de fond (disque etcd de k8s-2 chroniquement lent) — isolation disque à traiter séparément.

## Test

- 29/29 YAML valides, diff chirurgical (1 ligne/fichier), pre-commit hooks passés.
- Pattern `\${VAR:=default}` + texte littéral déjà éprouvé dans le même composant (`repository: \${APP}-volsync-secret`).