### PR TITLE
fix(openclaw): keep image automation git source

### DIFF
--- a/kubernetes/apps/default/elgato-photo/app/kustomization.yaml
+++ b/kubernetes/apps/default/elgato-photo/app/kustomization.yaml
@@ -13,4 +13,3 @@ resources:
   - ./receiver.yaml
   - ./harbor-registry-secret.yaml
   - ./github-auth-secret.yaml
-  - ./gitrepository-write.yaml

--- a/kubernetes/apps/default/openclaw/shared/gitrepository-write.yaml
+++ b/kubernetes/apps/default/openclaw/shared/gitrepository-write.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/gitrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: home-ops-write
+  namespace: default
+spec:
+  interval: 5m
+  url: https://github.com/mgueye01/home-ops
+  ref:
+    branch: main
+  secretRef:
+    name: github-auth

--- a/kubernetes/apps/default/openclaw/shared/kustomization.yaml
+++ b/kubernetes/apps/default/openclaw/shared/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - imagerepository.yaml
   - imagepolicy.yaml
   - imageupdateautomation.yaml
+  - gitrepository-write.yaml


### PR DESCRIPTION
## Summary
- move the shared writable GitRepository source into openclaw shared resources
- stop elgato-photo from owning that shared source when re-enabled

## Validation
- kubectl kustomize kubernetes/apps/default/openclaw/shared
- kubectl kustomize kubernetes/apps/default/elgato-photo/app
- kubectl apply --dry-run=server -f /tmp/openclaw-shared-rendered.yaml