### PR TITLE
fix(openclaw): keep github auth secret source

### DIFF
--- a/kubernetes/apps/default/elgato-photo/app/kustomization.yaml
+++ b/kubernetes/apps/default/elgato-photo/app/kustomization.yaml
@@ -12,4 +12,3 @@ resources:
   - ./imageupdateautomation.yaml
   - ./receiver.yaml
   - ./harbor-registry-secret.yaml
-  - ./github-auth-secret.yaml

--- a/kubernetes/apps/default/openclaw/shared/github-auth-secret.yaml
+++ b/kubernetes/apps/default/openclaw/shared/github-auth-secret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: github-auth
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: github-auth
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        username: "{{ .GITHUB_USERNAME }}"
+        password: "{{ .FLUX_GITHUB_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: flux

--- a/kubernetes/apps/default/openclaw/shared/kustomization.yaml
+++ b/kubernetes/apps/default/openclaw/shared/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - imagepolicy.yaml
   - imageupdateautomation.yaml
   - gitrepository-write.yaml
+  - github-auth-secret.yaml


### PR DESCRIPTION
## Summary
- move the github-auth ExternalSecret into openclaw shared resources with the GitRepository it serves
- stop elgato-photo from owning the shared auth source when re-enabled

## Validation
- kubectl kustomize kubernetes/apps/default/openclaw/shared
- kubectl kustomize kubernetes/apps/default/elgato-photo/app
- kubectl apply --dry-run=server -f /tmp/openclaw-shared-rendered.yaml