### PR TITLE
fix(csi-driver-nfs): grant resizer pod watch rbac

### DIFF
--- a/kubernetes/apps/kube-system/csi-driver-nfs/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/csi-driver-nfs/app/helmrelease.yaml
@@ -94,3 +94,18 @@ spec:
                           - "--leader-election-lease-duration=60s"
                           - "--leader-election-renew-deadline=30s"
                           - "--leader-election-retry-period=15s"
+          - target:
+              kind: ClusterRole
+              name: nfs-external-resizer-role
+            patch: |
+              - op: add
+                path: /rules/-
+                value:
+                  apiGroups:
+                    - ""
+                  resources:
+                    - pods
+                  verbs:
+                    - get
+                    - list
+                    - watch


### PR DESCRIPTION
## Summary
- add read-only pod watch/list/get RBAC to the NFS CSI external-resizer ClusterRole
- fixes repeated csi-resizer forbidden reflector errors after v2.2.0 rollout

## Validation
- kubectl apply --dry-run=server -f kubernetes/apps/kube-system/csi-driver-nfs/app/helmrelease.yaml