### PR TITLE
fix(karakeep): co-locate meilisearch with app pod

### DIFF
--- a/kubernetes/apps/default/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/default/karakeep/app/helmrelease.yaml
@@ -97,6 +97,10 @@ spec:
                         operator: In
                         values:
                           - *app
+                      - key: app.kubernetes.io/controller
+                        operator: In
+                        values:
+                          - *app
                   topologyKey: kubernetes.io/hostname
         containers:
           app:


### PR DESCRIPTION
## Summary
- tighten Karakeep Meilisearch podAffinity so it matches the Karakeep app controller, not Meilisearch itself
- avoids scheduling Meilisearch on a different node while both controllers share the same RWO PVC via subPaths

## Evidence
- karakeep-meilisearch is stuck ContainerCreating with Ceph Multi-Attach because the PVC is already mounted by karakeep on another node
- YAML parse and git diff checks passed

## Risk
- touches scheduling for a stateful workload sharing a PVC; merge needs operator validation before changing live placement