### PR TITLE
fix(unpoller): rollback to v3.3.1

### DIFF
--- a/kubernetes/apps/observability/unpoller/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/unpoller/app/helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
           app:
             image:
               repository: ghcr.io/unpoller/unpoller
-              tag: v3.3.3@sha256:e84e0fa3427548df4cc1f4e1922dd93fab5a67ae774b80b69e3a52041e88ef05
+              tag: v3.3.1@sha256:9dcccdc931a6830735f6978caf8cd67699b0dc33e37cf9ef4638611791c4df62
             env:
               TZ: Europe/Paris
               UP_UNIFI_DEFAULT_ROLE: home-ops


### PR DESCRIPTION
Rollback unpoller from v3.3.3 to the previously healthy v3.3.1 image because Flux/Helm failed to complete the upgrade and the live deployment remains healthy on v3.3.1.\n\nValidation:\n- git diff --check\n- YAML parse for kubernetes/apps/observability/unpoller/app/helmrelease.yaml\n- live unpoller pod is Running 1/1 on v3.3.1