### PR TITLE
fix(unpoller): add startup probe grace period

### DIFF
--- a/kubernetes/apps/observability/unpoller/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/unpoller/app/helmrelease.yaml
@@ -35,6 +35,15 @@ spec:
               - secretRef:
                   name: unpoller-secret
             probes:
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 80
+                  periodSeconds: 5
+                  timeoutSeconds: 1
+                  failureThreshold: 24
               liveness:
                 enabled: true
               readiness:


### PR DESCRIPTION
Unpoller is currently CrashLooping after the v3.3.3 rollout/rollback path because the container is killed by liveness before port 80 starts accepting connections.\n\nThis adds a TCP startup probe with up to 120s grace so liveness/readiness do not kill slow startup prematurely.\n\nValidation:\n- kubectl kustomize ./kubernetes/apps/observability/unpoller/app\n- kubectl apply --dry-run=client -f rendered manifest