### PR TITLE
fix(karakeep): remove removed Meilisearch flag

### DIFF
--- a/kubernetes/apps/default/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/default/karakeep/app/helmrelease.yaml
@@ -111,7 +111,6 @@ spec:
               tag: v1.51.0
             args:
               - /bin/meilisearch
-              - --experimental-dumpless-upgrade
             env:
               MEILI_NO_ANALYTICS: true
               MEILI_MASTER_KEY:


### PR DESCRIPTION
## Summary
- remove the removed Meilisearch `--experimental-dumpless-upgrade` flag from Karakeep's Meilisearch container args

## Why
Meilisearch v1.51.0 no longer accepts this flag, causing the Karakeep Meilisearch pod to CrashLoop.

## Validation
- `python3 - <<'PY' ... yaml.safe_load(...)` → yaml ok
- `git diff --check` → ok