### PR TITLE
fix(karakeep): allow Meilisearch DB upgrade

### DIFF
--- a/kubernetes/apps/default/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/default/karakeep/app/helmrelease.yaml
@@ -111,6 +111,7 @@ spec:
               tag: v1.51.0
             args:
               - /bin/meilisearch
+              - --upgrade-db
             env:
               MEILI_NO_ANALYTICS: true
               MEILI_MASTER_KEY:


### PR DESCRIPTION
## Summary
- add `--upgrade-db` for Karakeep's Meilisearch v1.50 → v1.51 data upgrade

## Why
After removing `--experimental-dumpless-upgrade`, Meilisearch v1.51 starts but refuses the existing v1.50 database unless `--upgrade-db` is set.

## Validation
- YAML parse: ok
- `git diff --check`: ok