### PR TITLE
fix(coredns): suppress unreachable external AAAA records

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -46,13 +46,11 @@ spec:
               fallthrough in-addr.arpa ip6.arpa
           - name: autopath
             parameters: "@kubernetes"
-          # g-eye.tech is home-only: the LAN resolver holds A records, but AAAA
-          # is forwarded to the parked public zone and SERVFAILs. Node resolves
-          # AF_UNSPEC (A + AAAA), so the SERVFAIL surfaces as getaddrinfo
-          # EAI_AGAIN and breaks S3 calls to nas.g-eye.tech. Answer AAAA with
-          # NOERROR/NODATA here instead of forwarding.
+          # The cluster is IPv4-only (Cilium IPv6 is disabled), so forwarding
+          # public AAAA answers makes clients attempt unreachable IPv6 endpoints.
+          # Answer AAAA with NOERROR/NODATA and force external traffic over IPv4.
           - name: template
-            parameters: IN AAAA g-eye.tech
+            parameters: IN AAAA .
             configBlock: |-
               rcode NOERROR
           - name: forward


### PR DESCRIPTION
## Summary
- suppress public AAAA responses in the IPv4-only cluster
- prevent Flux, Alertmanager, External Secrets, and workloads from attempting unreachable IPv6 endpoints
- preserve A records and existing IPv4 egress

## Validation
- YAML parse
- kubectl client-side dry run
- kubectl kustomize render

## Risk / rollback
CoreDNS rolls two replicas progressively. IPv6-only public destinations remain unavailable, as they already are without an IPv6 route. Rollback is a one-line revert from `IN AAAA .` to `IN AAAA g-eye.tech`.